### PR TITLE
Add `accrueInterest` on swaps

### DIFF
--- a/pkg/pool-linear/contracts/LinearPoolV2.sol
+++ b/pkg/pool-linear/contracts/LinearPoolV2.sol
@@ -1,0 +1,672 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/BalancerErrors.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/ERC20Helpers.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+
+import "@balancer-labs/v2-pool-utils/contracts/LegacyBasePool.sol";
+import "@balancer-labs/v2-pool-utils/contracts/interfaces/IRateProvider.sol";
+import "@balancer-labs/v2-pool-utils/contracts/rates/PriceRateCache.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IGeneralPool.sol";
+
+import "./LinearMath.sol";
+import "./LinearPoolUserData.sol";
+
+/**
+ * @dev Linear Pools are designed to hold two assets: "main" and "wrapped" tokens that have an equal value underlying
+ * token (e.g., DAI and waDAI). There must be an external feed available to provide an exact, non-manipulable exchange
+ * rate between the tokens. In particular, any reversible manipulation (e.g. causing the rate to increase and then
+ * decrease) can lead to severe issues and loss of funds.
+ *
+ * The Pool will register three tokens in the Vault however: the two assets and the BPT itself,
+ * so that BPT can be exchanged (effectively joining and exiting) via swaps.
+ *
+ * Despite inheriting from BasePool, much of the basic behavior changes. This Pool does not support regular joins and
+ * exits, as the entire BPT supply is 'preminted' during initialization.
+ *
+ * Unlike most other Pools, this one does not attempt to create revenue by charging fees: value is derived by holding
+ * the wrapped, yield-bearing asset. However, the 'swap fee percentage' value is still used, albeit with a different
+ * meaning. This Pool attempts to hold a certain amount of "main" tokens, between a lower and upper target value.
+ * The pool charges fees on trades that move the balance outside that range, which are then paid back as incentives to
+ * traders whose swaps return the balance to the desired region.
+ * The net revenue via fees is expected to be zero: all collected fees are used to pay for this 'rebalancing'.
+ */
+abstract contract LinearPoolV2 is LegacyBasePool, IGeneralPool, IRateProvider {
+    using WordCodec for bytes32;
+    using FixedPoint for uint256;
+    using PriceRateCache for bytes32;
+    using LinearPoolUserData for bytes;
+
+    uint256 private constant _TOTAL_TOKENS = 3; // Main token, wrapped token, BPT
+
+    // This is the maximum token amount the Vault can hold. In regular operation, the total BPT supply remains constant
+    // and equal to _INITIAL_BPT_SUPPLY, but most of it remains in the Pool, waiting to be exchanged for tokens. The
+    // actual amount of BPT in circulation is the total supply minus the amount held by the Pool, and is known as the
+    // 'virtual supply'.
+    // The total supply can only change if the emergency pause is activated by governance, enabling an
+    // alternative proportional exit that burns BPT. As this is not expected to happen, we optimize for
+    // success by using _INITIAL_BPT_SUPPLY instead of totalSupply(), saving a storage read. This optimization is only
+    // valid if the Pool is never paused: in case of an emergency that leads to burned tokens, the Pool should not
+    // be used after the buffer period expires and it automatically 'unpauses'.
+    uint256 private constant _INITIAL_BPT_SUPPLY = 2**(112) - 1;
+
+    IERC20 private immutable _mainToken;
+    IERC20 private immutable _wrappedToken;
+
+    // The indices of each token when registered, which can then be used to access the balances array.
+    uint256 private immutable _bptIndex;
+    uint256 private immutable _mainIndex;
+    uint256 private immutable _wrappedIndex;
+
+    // Both BPT and the main token have a regular, constant scaling factor (equal to FixedPoint.ONE for BPT, and
+    // dependent on the number of decimals for the main token). However, the wrapped token's scaling factor has two
+    // components: the usual token decimal scaling factor, and an externally provided rate used to convert wrapped
+    // tokens to an equivalent main token amount. This external rate is expected to be ever increasing, reflecting the
+    // fact that the wrapped token appreciates in value over time (e.g. because it is accruing interest).
+    uint256 private immutable _scalingFactorMainToken;
+    uint256 private immutable _scalingFactorWrappedToken;
+
+    // The lower and upper target are in BasePool's misc data field, which has 192 bits available (as it shares the same
+    // storage slot as the swap fee percentage, which is 64 bits). These are already scaled by the main token's scaling
+    // factor, which means that the maximum upper target is ~80 billion in the main token units if the token were to
+    // have 18 decimals (2^(192/2) / 10^18), which is more than enough.
+    // [        64 bits       |    96 bits   |    96 bits    ]
+    // [       reserved       | upper target |  lower target ]
+    // [  base pool swap fee  |         misc data            ]
+    // [ MSB                                             LSB ]
+
+    uint256 private constant _LOWER_TARGET_OFFSET = 0;
+    uint256 private constant _UPPER_TARGET_OFFSET = 96;
+
+    uint256 private constant _MAX_UPPER_TARGET = 2**(96) - 1;
+
+    event TargetsSet(IERC20 indexed token, uint256 lowerTarget, uint256 upperTarget);
+
+    constructor(
+        IVault vault,
+        string memory name,
+        string memory symbol,
+        IERC20 mainToken,
+        IERC20 wrappedToken,
+        uint256 upperTarget,
+        uint256 swapFeePercentage,
+        uint256 pauseWindowDuration,
+        uint256 bufferPeriodDuration,
+        address owner
+    )
+        LegacyBasePool(
+            vault,
+            IVault.PoolSpecialization.GENERAL,
+            name,
+            symbol,
+            _sortTokens(mainToken, wrappedToken, this),
+            new address[](_TOTAL_TOKENS),
+            swapFeePercentage,
+            pauseWindowDuration,
+            bufferPeriodDuration,
+            owner
+        )
+    {
+        // Set tokens
+        _mainToken = mainToken;
+        _wrappedToken = wrappedToken;
+
+        // Set token indexes
+        (uint256 mainIndex, uint256 wrappedIndex, uint256 bptIndex) = _getSortedTokenIndexes(
+            mainToken,
+            wrappedToken,
+            this
+        );
+        _bptIndex = bptIndex;
+        _mainIndex = mainIndex;
+        _wrappedIndex = wrappedIndex;
+
+        // Set scaling factors
+        _scalingFactorMainToken = _computeScalingFactor(mainToken);
+        _scalingFactorWrappedToken = _computeScalingFactor(wrappedToken);
+
+        // Set initial targets. Lower target must be set to zero because initially there are no fees accumulated.
+        // Otherwise the pool will owe fees at start which results in a manipulable rate.
+        uint256 lowerTarget = 0;
+        _setTargets(mainToken, lowerTarget, upperTarget);
+    }
+
+    function getMainToken() public view returns (address) {
+        return address(_mainToken);
+    }
+
+    function getWrappedToken() public view returns (address) {
+        return address(_wrappedToken);
+    }
+
+    function getBptIndex() external view returns (uint256) {
+        return _bptIndex;
+    }
+
+    function getMainIndex() external view returns (uint256) {
+        return _mainIndex;
+    }
+
+    function getWrappedIndex() external view returns (uint256) {
+        return _wrappedIndex;
+    }
+
+    /**
+     * @dev Finishes initialization of the Linear Pool: it is unusable before calling this function as no BPT will have
+     * been minted.
+     *
+     * Since Linear Pools have preminted BPT stored in the Vault, they require an initial join to deposit said BPT as
+     * their balance. Unfortunately, this cannot be performed during construction, as a join involves calling the
+     * `onJoinPool` function on the Pool, and the Pool will not have any code until construction finishes. Therefore,
+     * this must happen in a separate call.
+     *
+     * It is highly recommended to create Linear pools using the LinearPoolFactory, which calls `initialize`
+     * automatically.
+     */
+    function initialize() external {
+        bytes32 poolId = getPoolId();
+        (IERC20[] memory tokens, , ) = getVault().getPoolTokens(poolId);
+
+        // Joins typically involve the Pool receiving tokens in exchange for newly-minted BPT. In this case however, the
+        // Pool will mint the entire BPT supply to itself, and join itself with it.
+        uint256[] memory maxAmountsIn = new uint256[](_TOTAL_TOKENS);
+        maxAmountsIn[_bptIndex] = _INITIAL_BPT_SUPPLY;
+
+        // The first time this executes, it will call `_onInitializePool` (as the BPT supply will be zero). Future calls
+        // will be routed to `_onJoinPool`, which always reverts, meaning `initialize` will only execute once.
+        IVault.JoinPoolRequest memory request = IVault.JoinPoolRequest({
+            assets: _asIAsset(tokens),
+            maxAmountsIn: maxAmountsIn,
+            userData: "",
+            fromInternalBalance: false
+        });
+
+        getVault().joinPool(poolId, address(this), address(this), request);
+    }
+
+    /**
+     * @dev Implementation of onSwap, from IGeneralPool.
+     */
+    function onSwap(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        uint256 indexIn,
+        uint256 indexOut
+    ) public virtual override onlyVault(request.poolId) whenNotPaused returns (uint256) {
+        // In most Pools, swaps involve exchanging one token held by the Pool for another. In this case however, since
+        // one of the three tokens is the BPT itself, a swap might also be a join (main/wrapped for BPT) or an exit
+        // (BPT for main/wrapped).
+        // All three swap types (swaps, joins and exits) are fully disabled if the emergency pause is enabled. Under
+        // these circumstances, the Pool should be exited using the regular Vault.exitPool function.
+
+        // Sanity check: this is not entirely necessary as the Vault's interface enforces the indices to be valid, but
+        // the check is cheap to perform.
+        _require(indexIn < _TOTAL_TOKENS && indexOut < _TOTAL_TOKENS, Errors.OUT_OF_BOUNDS);
+
+        // Note that we already know the indices of the main token, wrapped token and BPT, so there is no need to pass
+        // these indices to the inner functions.
+
+        // Upscale balances by the scaling factors (taking into account the wrapped token rate)
+        uint256[] memory scalingFactors = _scalingFactors();
+        _upscaleArray(balances, scalingFactors);
+
+        (uint256 lowerTarget, uint256 upperTarget) = getTargets();
+        LinearMath.Params memory params = LinearMath.Params({
+            fee: getSwapFeePercentage(),
+            lowerTarget: lowerTarget,
+            upperTarget: upperTarget
+        });
+
+        if (request.kind == IVault.SwapKind.GIVEN_IN) {
+            // The amount given is for token in, the amount calculated is for token out
+            request.amount = _upscale(request.amount, scalingFactors[indexIn]);
+            uint256 amountOut = _onSwapGivenIn(request, balances, params);
+
+            // amountOut tokens are exiting the Pool, so we round down.
+            return _downscaleDown(amountOut, scalingFactors[indexOut]);
+        } else {
+            // The amount given is for token out, the amount calculated is for token in
+            request.amount = _upscale(request.amount, scalingFactors[indexOut]);
+            uint256 amountIn = _onSwapGivenOut(request, balances, params);
+
+            // amountIn tokens are entering the Pool, so we round up.
+            return _downscaleUp(amountIn, scalingFactors[indexIn]);
+        }
+    }
+
+    function _onSwapGivenIn(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        if (request.tokenIn == this) {
+            return _swapGivenBptIn(request, balances, params);
+        } else if (request.tokenIn == _mainToken) {
+            return _swapGivenMainIn(request, balances, params);
+        } else if (request.tokenIn == _wrappedToken) {
+            return _swapGivenWrappedIn(request, balances, params);
+        } else {
+            _revert(Errors.INVALID_TOKEN);
+        }
+    }
+
+    function _swapGivenBptIn(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenOut == _mainToken || request.tokenOut == _wrappedToken, Errors.INVALID_TOKEN);
+        return
+            (request.tokenOut == _mainToken ? LinearMath._calcMainOutPerBptIn : LinearMath._calcWrappedOutPerBptIn)(
+                request.amount,
+                balances[_mainIndex],
+                balances[_wrappedIndex],
+                _getApproximateVirtualSupply(balances[_bptIndex]),
+                params
+            );
+    }
+
+    function _swapGivenMainIn(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenOut == _wrappedToken || request.tokenOut == this, Errors.INVALID_TOKEN);
+        return
+            request.tokenOut == this
+                ? LinearMath._calcBptOutPerMainIn(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _getApproximateVirtualSupply(balances[_bptIndex]),
+                    params
+                )
+                : LinearMath._calcWrappedOutPerMainIn(request.amount, balances[_mainIndex], params);
+    }
+
+    function _swapGivenWrappedIn(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenOut == _mainToken || request.tokenOut == this, Errors.INVALID_TOKEN);
+        return
+            request.tokenOut == this
+                ? LinearMath._calcBptOutPerWrappedIn(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _getApproximateVirtualSupply(balances[_bptIndex]),
+                    params
+                )
+                : LinearMath._calcMainOutPerWrappedIn(request.amount, balances[_mainIndex], params);
+    }
+
+    function _onSwapGivenOut(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        if (request.tokenOut == this) {
+            return _swapGivenBptOut(request, balances, params);
+        } else if (request.tokenOut == _mainToken) {
+            return _swapGivenMainOut(request, balances, params);
+        } else if (request.tokenOut == _wrappedToken) {
+            return _swapGivenWrappedOut(request, balances, params);
+        } else {
+            _revert(Errors.INVALID_TOKEN);
+        }
+    }
+
+    function _swapGivenBptOut(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenIn == _mainToken || request.tokenIn == _wrappedToken, Errors.INVALID_TOKEN);
+        return
+            (request.tokenIn == _mainToken ? LinearMath._calcMainInPerBptOut : LinearMath._calcWrappedInPerBptOut)(
+                request.amount,
+                balances[_mainIndex],
+                balances[_wrappedIndex],
+                _getApproximateVirtualSupply(balances[_bptIndex]),
+                params
+            );
+    }
+
+    function _swapGivenMainOut(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenIn == _wrappedToken || request.tokenIn == this, Errors.INVALID_TOKEN);
+        return
+            request.tokenIn == this
+                ? LinearMath._calcBptInPerMainOut(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _getApproximateVirtualSupply(balances[_bptIndex]),
+                    params
+                )
+                : LinearMath._calcWrappedInPerMainOut(request.amount, balances[_mainIndex], params);
+    }
+
+    function _swapGivenWrappedOut(
+        SwapRequest memory request,
+        uint256[] memory balances,
+        LinearMath.Params memory params
+    ) internal view returns (uint256) {
+        _require(request.tokenIn == _mainToken || request.tokenIn == this, Errors.INVALID_TOKEN);
+        return
+            request.tokenIn == this
+                ? LinearMath._calcBptInPerWrappedOut(
+                    request.amount,
+                    balances[_mainIndex],
+                    balances[_wrappedIndex],
+                    _getApproximateVirtualSupply(balances[_bptIndex]),
+                    params
+                )
+                : LinearMath._calcMainInPerWrappedOut(request.amount, balances[_mainIndex], params);
+    }
+
+    function _onInitializePool(
+        bytes32,
+        address sender,
+        address recipient,
+        uint256[] memory,
+        bytes memory
+    ) internal view override whenNotPaused returns (uint256, uint256[] memory) {
+        // Linear Pools can only be initialized by the Pool performing the initial join via the `initialize` function.
+        _require(sender == address(this), Errors.INVALID_INITIALIZATION);
+        _require(recipient == address(this), Errors.INVALID_INITIALIZATION);
+
+        // The full BPT supply will be minted and deposited in the Pool. Note that there is no need to approve the Vault
+        // as it already has infinite BPT allowance.
+        uint256 bptAmountOut = _INITIAL_BPT_SUPPLY;
+
+        uint256[] memory amountsIn = new uint256[](_TOTAL_TOKENS);
+        amountsIn[_bptIndex] = _INITIAL_BPT_SUPPLY;
+
+        return (bptAmountOut, amountsIn);
+    }
+
+    function _onJoinPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory
+    )
+        internal
+        pure
+        override
+        returns (
+            uint256,
+            uint256[] memory,
+            uint256[] memory
+        )
+    {
+        _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+    }
+
+    function _onExitPool(
+        bytes32,
+        address,
+        address,
+        uint256[] memory balances,
+        uint256,
+        uint256,
+        uint256[] memory,
+        bytes memory userData
+    )
+        internal
+        view
+        override
+        returns (
+            uint256 bptAmountIn,
+            uint256[] memory amountsOut,
+            uint256[] memory dueProtocolFeeAmounts
+        )
+    {
+        // Exits typically revert, except for the proportional exit when the emergency pause mechanism has been
+        // triggered. This allows for a simple and safe way to exit the Pool.
+
+        // Note that the rate cache will not be automatically updated in such a scenario (though this can be still done
+        // manually). This however should not lead to any issues as the rate is not important during the emergency exit.
+        // On the contrary, decoupling the rate provider from the emergency exit might be useful under these
+        // circumstances.
+
+        LinearPoolUserData.ExitKind kind = userData.exitKind();
+        if (kind != LinearPoolUserData.ExitKind.EMERGENCY_EXACT_BPT_IN_FOR_TOKENS_OUT) {
+            _revert(Errors.UNHANDLED_BY_LINEAR_POOL);
+        } else {
+            _ensurePaused();
+            // Note that this will cause the user's BPT to be burned, which is not something that happens during
+            // regular operation of this Pool, and may lead to accounting errors. Because of this, it is highly
+            // advisable to stop using a Pool after it is paused and the pause window expires.
+
+            (bptAmountIn, amountsOut) = _emergencyProportionalExit(balances, userData);
+
+            // Due protocol fees are set to zero as this Pool accrues no fees and pays no protocol fees.
+            dueProtocolFeeAmounts = new uint256[](_getTotalTokens());
+        }
+    }
+
+    function _emergencyProportionalExit(uint256[] memory balances, bytes memory userData)
+        private
+        view
+        returns (uint256, uint256[] memory)
+    {
+        // This proportional exit function is only enabled if the contract is paused, to provide users a way to
+        // retrieve their tokens in case of an emergency.
+        //
+        // This particular exit function is the only one available because it is the simplest, and therefore least
+        // likely to be incorrect, or revert and lock funds.
+
+        uint256 bptAmountIn = userData.exactBptInForTokensOut();
+        // Note that there is no minimum amountOut parameter: this is handled by `IVault.exitPool`.
+
+        // This process burns BPT, rendering `_getApproximateVirtualSupply` inaccurate, so we use the real method here
+        uint256[] memory amountsOut = LinearMath._calcTokensOutGivenExactBptIn(
+            balances,
+            bptAmountIn,
+            _getVirtualSupply(balances[_bptIndex]),
+            _bptIndex
+        );
+
+        return (bptAmountIn, amountsOut);
+    }
+
+    function _getMaxTokens() internal pure override returns (uint256) {
+        return _TOTAL_TOKENS;
+    }
+
+    function _getMinimumBpt() internal pure override returns (uint256) {
+        // Linear Pools don't lock any BPT, as the total supply will already be forever non-zero due to the preminting
+        // mechanism, ensuring initialization only occurs once.
+        return 0;
+    }
+
+    function _getTotalTokens() internal view virtual override returns (uint256) {
+        return _TOTAL_TOKENS;
+    }
+
+    function _scalingFactor(IERC20 token) internal view virtual override returns (uint256) {
+        if (token == _mainToken) {
+            return _scalingFactorMainToken;
+        } else if (token == _wrappedToken) {
+            // The wrapped token's scaling factor is not constant, but increases over time as the wrapped token
+            // increases in value.
+            return _scalingFactorWrappedToken.mulDown(_getWrappedTokenRate());
+        } else if (token == this) {
+            return FixedPoint.ONE;
+        } else {
+            _revert(Errors.INVALID_TOKEN);
+        }
+    }
+
+    function _scalingFactors() internal view virtual override returns (uint256[] memory) {
+        uint256[] memory scalingFactors = new uint256[](_TOTAL_TOKENS);
+
+        // The wrapped token's scaling factor is not constant, but increases over time as the wrapped token increases in
+        // value.
+        scalingFactors[_mainIndex] = _scalingFactorMainToken;
+        scalingFactors[_wrappedIndex] = _scalingFactorWrappedToken.mulDown(_getWrappedTokenRate());
+        scalingFactors[_bptIndex] = FixedPoint.ONE;
+
+        return scalingFactors;
+    }
+
+    // Price rates
+
+    /**
+     * @dev For a Linear Pool, the rate represents the appreciation of BPT with respect to the underlying tokens. This
+     * rate increases slowly as the wrapped token appreciates in value.
+     */
+    function getRate() external view override returns (uint256) {
+        bytes32 poolId = getPoolId();
+        (, uint256[] memory balances, ) = getVault().getPoolTokens(poolId);
+        _upscaleArray(balances, _scalingFactors());
+
+        (uint256 lowerTarget, uint256 upperTarget) = getTargets();
+        LinearMath.Params memory params = LinearMath.Params({
+            fee: getSwapFeePercentage(),
+            lowerTarget: lowerTarget,
+            upperTarget: upperTarget
+        });
+
+        uint256 totalBalance = LinearMath._calcInvariant(
+            LinearMath._toNominal(balances[_mainIndex], params),
+            balances[_wrappedIndex]
+        );
+
+        // Note that we're dividing by the virtual supply, which may be zero (causing this call to revert). However, the
+        // only way for that to happen would be for all LPs to exit the Pool, and nothing prevents new LPs from
+        // joining it later on.
+        return totalBalance.divUp(_getApproximateVirtualSupply(balances[_bptIndex]));
+    }
+
+    function getWrappedTokenRate() external view returns (uint256) {
+        return _getWrappedTokenRate();
+    }
+
+    /**
+     * @dev Should be 1e18 for the subsequent calculation of the wrapper token scaling factor.
+     */
+    function _getWrappedTokenRate() internal view virtual returns (uint256);
+
+    function getTargets() public view returns (uint256 lowerTarget, uint256 upperTarget) {
+        bytes32 miscData = _getMiscData();
+        lowerTarget = miscData.decodeUint96(_LOWER_TARGET_OFFSET);
+        upperTarget = miscData.decodeUint96(_UPPER_TARGET_OFFSET);
+    }
+
+    function _setTargets(
+        IERC20 mainToken,
+        uint256 lowerTarget,
+        uint256 upperTarget
+    ) private {
+        _require(lowerTarget <= upperTarget, Errors.LOWER_GREATER_THAN_UPPER_TARGET);
+        _require(upperTarget <= _MAX_UPPER_TARGET, Errors.UPPER_TARGET_TOO_HIGH);
+
+        // Pack targets as two uint96 values into a single storage slot. This results in targets being capped to 96
+        // bits, but that should be more than enough.
+        _setMiscData(
+            WordCodec.encodeUint(lowerTarget, _LOWER_TARGET_OFFSET) |
+                WordCodec.encodeUint(upperTarget, _UPPER_TARGET_OFFSET)
+        );
+
+        emit TargetsSet(mainToken, lowerTarget, upperTarget);
+    }
+
+    function setTargets(uint256 newLowerTarget, uint256 newUpperTarget) external authenticate {
+        // For a new target range to be valid:
+        //  - the pool must currently be between the current targets (meaning no fees are currently pending)
+        //  - the pool must currently be between the new targets (meaning setting them does not cause for fees to be
+        //    pending)
+        //
+        // The first requirement could be relaxed, as the LPs actually benefit from the pending fees not being paid out,
+        // but being stricter makes analysis easier at little expense.
+
+        (uint256 currentLowerTarget, uint256 currentUpperTarget) = getTargets();
+        _require(_isMainBalanceWithinTargets(currentLowerTarget, currentUpperTarget), Errors.OUT_OF_TARGET_RANGE);
+        _require(_isMainBalanceWithinTargets(newLowerTarget, newUpperTarget), Errors.OUT_OF_NEW_TARGET_RANGE);
+
+        _setTargets(_mainToken, newLowerTarget, newUpperTarget);
+    }
+
+    function setSwapFeePercentage(uint256 swapFeePercentage) public override {
+        // For the swap fee percentage to be changeable:
+        //  - the pool must currently be between the current targets (meaning no fees are currently pending)
+        //
+        // As the amount of accrued fees is not explicitly stored but rather derived from the main token balance and the
+        // current swap fee percentage, requiring for no fees to be pending prevents the fee setter from changing the
+        // amount of pending fees, which they could use to e.g. drain Pool funds in the form of inflated fees.
+
+        (uint256 lowerTarget, uint256 upperTarget) = getTargets();
+        _require(_isMainBalanceWithinTargets(lowerTarget, upperTarget), Errors.OUT_OF_TARGET_RANGE);
+
+        super.setSwapFeePercentage(swapFeePercentage);
+    }
+
+    function _isMainBalanceWithinTargets(uint256 lowerTarget, uint256 upperTarget) private view returns (bool) {
+        bytes32 poolId = getPoolId();
+        (, uint256[] memory balances, ) = getVault().getPoolTokens(poolId);
+        uint256 mainTokenBalance = _upscale(balances[_mainIndex], _scalingFactor(_mainToken));
+
+        return mainTokenBalance >= lowerTarget && mainTokenBalance <= upperTarget;
+    }
+
+    function _isOwnerOnlyAction(bytes32 actionId) internal view virtual override returns (bool) {
+        return actionId == getActionId(this.setTargets.selector) || super._isOwnerOnlyAction(actionId);
+    }
+
+    /**
+     * @dev Returns the number of tokens in circulation.
+     *
+     * In other pools, this would be the same as `totalSupply`, but since this pool pre-mints all BPT, `totalSupply`
+     * remains constant, whereas `virtualSupply` increases as users join the pool and decreases as they exit it.
+     */
+    function getVirtualSupply() external view returns (uint256) {
+        (, uint256[] memory balances, ) = getVault().getPoolTokens(getPoolId());
+        // We technically don't need to upscale the BPT balance as its scaling factor is equal to one (since BPT has
+        // 18 decimals), but we do it for completeness.
+        uint256 bptBalance = _upscale(balances[_bptIndex], _scalingFactor(this));
+
+        return _getVirtualSupply(bptBalance);
+    }
+
+    function _getVirtualSupply(uint256 bptBalance) internal view returns (uint256) {
+        return totalSupply().sub(bptBalance);
+    }
+
+    /**
+     * @dev Computes an approximation of virtual supply, which costs less gas than `_getVirtualSupply` and returns the
+     * same value in all cases except when the emergency pause has been enabled and BPT burned as part of the emergency
+     * exit process.
+     */
+    function _getApproximateVirtualSupply(uint256 bptBalance) internal pure returns (uint256) {
+        // No need for checked arithmetic as _INITIAL_BPT_SUPPLY is always greater than any valid Vault BPT balance.
+        return _INITIAL_BPT_SUPPLY - bptBalance;
+    }
+}

--- a/pkg/pool-linear/contracts/ola/OlaLinearPoolFactory.sol
+++ b/pkg/pool-linear/contracts/ola/OlaLinearPoolFactory.sol
@@ -41,10 +41,10 @@ contract OlaLinearPoolFactory is BasePoolSplitCodeFactory, FactoryWidePauseWindo
         uint256 upperTarget,
         uint256 swapFeePercentage,
         address owner
-    ) external returns (LinearPool) {
+    ) external returns (LinearPoolV2) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
-        LinearPool pool = OlaLinearPool(
+        LinearPoolV2 pool = OlaLinearPool(
             _create(
                 abi.encode(
                     getVault(),

--- a/pkg/pool-linear/package.json
+++ b/pkg/pool-linear/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@balancer-labs/v2-pool-linear",
-  "version": "0.1.0",
-  "description": "Balancer V2 Linear Pools",
+  "name": "@ape.swap/v2-pool-linear",
+  "version": "0.1.1",
+  "description": "ApeSwap V2 Linear Pools",
   "license": "GPL-3.0-only",
-  "homepage": "https://github.com/balancer-labs/balancer-v2-monorepo/tree/master/pkg/pool-linear#readme",
+  "homepage": "https://github.com/ApeSwapFinance/apeswap-swap-v2-monorepo/tree/main/pkg/pool-linear#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/balancer-labs/balancer-v2-monorepo.git",
+    "url": "https://github.com/ApeSwapFinance/apeswap-swap-v2-monorepo.git",
     "directory": "pkg/pool-linear"
   },
   "bugs": {
-    "url": "https://github.com/balancer-labs/balancer-v2-monorepo/issues"
+    "url": "https://github.com/ApeSwapFinance/apeswap-swap-v2-monorepo/issues"
   },
   "files": [
     "contracts/**/*",


### PR DESCRIPTION
- The `LinearPool` contract was updated to `LinearPoolV2` to make `onSwap` non-`view` and `virtual`. Find the diff here: [LinearPoolV2 Diff](https://www.diffchecker.com/JNhqHB8d)
- `override` `function onSwap` in `OlaLinearPool.sol` to ensure arbitrageurs can't siphon off interest.